### PR TITLE
Invitados command

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ controller.on('team_join', onboard);
 /**
  * Invited guests
  */
-controller.hears(['mis panas', 'invitados'], 'direct_message', guests);
+controller.hears(['mis parceros', 'invitados'], 'direct_message', guests);
 
 /**
  * Help

--- a/index.js
+++ b/index.js
@@ -63,7 +63,9 @@ controller.hears('invite', 'direct_mention', (bot, message) => {
  */
 controller.on('team_join', onboard);
 
-
+/**
+ * Invited guests
+ */
 controller.hears(['mis panas', 'invitados'], 'direct_message', invitados);
 
 /**

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ let bot = controller.spawn({
 });
 
 bot.startRTM((err, bot, payload) => {
-  debug('err', err);
   if (err) { throw new Error('Could not connect to Slack'); }
 });
 
@@ -66,7 +65,7 @@ controller.on('team_join', onboard);
 /**
  * Invited guests
  */
-controller.hears(['mis parceros', 'invitados'], 'direct_message', guests);
+controller.hears(['parceros', 'llaverias', 'neas', 'ñeros', 'invitados'], 'direct_message', guests);
 
 /**
  * Help

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ checkConfig(config, ['SLACK_TOKEN', 'SLACK_ADMIN_TOKEN', 'SLACK_TEAM_NAME', 'DEB
 const Botkit = require('botkit');
 const invite = require('./lib/invite');
 const onboard = require('./lib/onboard');
-const invitados = require('./lib/invitados');
+const guests = require('./lib/guests');
 const storage = require('botkit-storage-mongo')({ mongoUri: config.MONGO_URI });
 const debug = require('debug')('bot:main');
 const packageInfo = require('./package.json');
@@ -66,7 +66,7 @@ controller.on('team_join', onboard);
 /**
  * Invited guests
  */
-controller.hears(['mis panas', 'invitados'], 'direct_message', invitados);
+controller.hears(['mis panas', 'invitados'], 'direct_message', guests);
 
 /**
  * Help

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ checkConfig(config, ['SLACK_TOKEN', 'SLACK_ADMIN_TOKEN', 'SLACK_TEAM_NAME', 'DEB
 const Botkit = require('botkit');
 const invite = require('./lib/invite');
 const onboard = require('./lib/onboard');
+const invitados = require('./lib/invitados');
 const storage = require('botkit-storage-mongo')({ mongoUri: config.MONGO_URI });
 const debug = require('debug')('bot:main');
 const packageInfo = require('./package.json');
@@ -27,6 +28,7 @@ let bot = controller.spawn({
 });
 
 bot.startRTM((err, bot, payload) => {
+  debug('err', err);
   if (err) { throw new Error('Could not connect to Slack'); }
 });
 
@@ -60,6 +62,9 @@ controller.hears('invite', 'direct_mention', (bot, message) => {
  * slack events easily right now
  */
 controller.on('team_join', onboard);
+
+
+controller.hears(['mis panas', 'invitados'], 'direct_message', invitados);
 
 /**
  * Help

--- a/lib/guests.js
+++ b/lib/guests.js
@@ -8,6 +8,11 @@ function guests(bot, message) {
   debug('begin');
   let user = message.user;
   let getData = Promise.promisify(bot.botkit.storage.users.get);
+  let guestsInviteResults = {
+    ok: 'Invitado',
+    already_invited: 'Ya se invitó',
+    already_in_team: 'Ya está registrado',
+  };
 
   return getData(user)
     .then((data) => {
@@ -18,15 +23,10 @@ function guests(bot, message) {
         return bot.reply(message, 'Oe, invitá un parcero primero!');
       }
 
-      const activeGuests = data.guests.filter((guest) => guest.result === 'ok');
-      if (activeGuests.length === 0) {
-        return bot.reply(message, 'No hay parceros activos, invitá uno ome!');
-      }
-
       return bot.reply(message, [
           'Tus parceros:',
           '\n',
-          `${activeGuests.map((guest) => guest.guest).join('\n')}`,
+          `${data.guests.map((guest) => `${guest.guest}: ${guestsInviteResults[guest.result]}`).join('\n')}`,
         ].join(' '));
     })
     .catch(err => {

--- a/lib/guests.js
+++ b/lib/guests.js
@@ -8,11 +8,6 @@ function guests(bot, message) {
   debug('begin');
   let user = message.user;
   let getData = Promise.promisify(bot.botkit.storage.users.get);
-  let guestsInviteResults = {
-    ok: 'Invitado',
-    already_invited: 'Ya se invitó',
-    already_in_team: 'Ya está registrado',
-  };
 
   return getData(user)
     .then((data) => {
@@ -23,16 +18,26 @@ function guests(bot, message) {
         return bot.reply(message, 'Oe, invitá un parcero primero!');
       }
 
-      return bot.reply(message, [
-          'Tus parceros:',
-          '\n',
-          `${data.guests.map((guest) => `${guest.guest}: ${guestsInviteResults[guest.result]}`).join('\n')}`,
-        ].join(' '));
+      return bot.reply(message, formatOutput(data.guests));
     })
     .catch(err => {
       logError('caught', err);
       return bot.reply(message, 'Error - servidor falló');
     });
+}
+
+function formatOutput(guests) {
+  let guestsInviteResults = {
+    ok: 'Invitado',
+    already_invited: 'Ya se invitó',
+    already_in_team: 'Ya está registrado',
+  };
+
+  return [
+    'Tus parceros:',
+    '\n',
+    `${guests.map((guest) => `${guest.guest}: ${guestsInviteResults[guest.result] || guest.result}`).join('\n')}`,
+  ].join(' ');
 }
 
 module.exports = guests;

--- a/lib/guests.js
+++ b/lib/guests.js
@@ -15,7 +15,7 @@ function guests(bot, message) {
       debug('panas', data.guests);
 
       if (data.guests.length === 0) {
-        return bot.reply(message, 'Oiga, invitá un parcero primero!');
+        return bot.reply(message, 'Oe, invitá un parcero primero!');
       }
 
       const activeGuests = data.guests.filter((guest) => guest.result === 'ok');
@@ -30,18 +30,6 @@ function guests(bot, message) {
         ].join(' '));
     })
     .catch(err => {
-      debug('catch');
-      let serverError = (err.res && err.res.statusCode !== 200);
-
-      if (serverError) {
-        err.reply = `El servidor respondió de mala gana con estatus ${err.res.statusCode}`;
-      }
-
-      if (err.reply) {
-        logError('caught', err.reply);
-        return bot.reply(message, err.reply);
-      }
-
       logError('caught', err);
       return bot.reply(message, 'Error - servidor falló');
     });

--- a/lib/guests.js
+++ b/lib/guests.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const Promise = require('bluebird');
-const debug = require('debug')('bot:invitados');
+const debug = require('debug')('bot:guests');
 const logError = require('debug')('bot:error');
 
-function invitados(bot, message) {
+function guests(bot, message) {
   debug('begin');
   let user = message.user;
   let getData = Promise.promisify(bot.botkit.storage.users.get);
@@ -15,16 +15,16 @@ function invitados(bot, message) {
       debug('panas', data.guests);
 
       if (data.guests.length === 0) {
-        return bot.reply(message, 'Oiga, invitá un pana primero!');
+        return bot.reply(message, 'Oiga, invitá un llavería primero!');
       }
 
       const activeGuests = data.guests.filter((guest) => guest.result === 'ok');
       if (activeGuests.length === 0) {
-        return bot.reply(message, 'No hay panas activos, invitá uno!');
+        return bot.reply(message, 'No hay llaverías activos, invitá uno ome!');
       }
 
       return bot.reply(message, [
-          'Tus panas:',
+          'Tus llaverías:',
           '\n',
           `${activeGuests.map((guest) => guest.guest).join('\n')}`,
         ].join(' '));
@@ -47,4 +47,4 @@ function invitados(bot, message) {
     });
 }
 
-module.exports = invitados;
+module.exports = guests;

--- a/lib/guests.js
+++ b/lib/guests.js
@@ -15,16 +15,16 @@ function guests(bot, message) {
       debug('panas', data.guests);
 
       if (data.guests.length === 0) {
-        return bot.reply(message, 'Oiga, invitá un llavería primero!');
+        return bot.reply(message, 'Oiga, invitá un parcero primero!');
       }
 
       const activeGuests = data.guests.filter((guest) => guest.result === 'ok');
       if (activeGuests.length === 0) {
-        return bot.reply(message, 'No hay llaverías activos, invitá uno ome!');
+        return bot.reply(message, 'No hay parceros activos, invitá uno ome!');
       }
 
       return bot.reply(message, [
-          'Tus llaverías:',
+          'Tus parceros:',
           '\n',
           `${activeGuests.map((guest) => guest.guest).join('\n')}`,
         ].join(' '));

--- a/lib/invitados.js
+++ b/lib/invitados.js
@@ -16,17 +16,16 @@ function invitados(bot, message) {
       debug('pana', data);
       debug('panas', data.guests);
 
-      if(data.guests.length === 0) {
+      if (data.guests.length === 0) {
         return bot.reply(message, 'Oiga, invitá un pana primero!');
       }
 
       const activeGuests = data.guests.filter((guest) => guest.result === 'ok');
-      debug({ activeGuests });
-      if(activeGuests.length > 0) {
+      if (activeGuests.length > 0) {
         return bot.reply(message, [
           'Tus panas:',
           '\n',
-          `${activeGuests.map((guest) => guest.guest).join('\n')}`
+          `${activeGuests.map((guest) => guest.guest).join('\n')}`,
         ].join(' '));
       }
     })
@@ -45,7 +44,7 @@ function invitados(bot, message) {
 
       logError('caught', err);
       return bot.reply(message, 'Error - servidor falló');
-    })
+    });
 }
 
 module.exports = invitados;

--- a/lib/invitados.js
+++ b/lib/invitados.js
@@ -21,13 +21,15 @@ function invitados(bot, message) {
       }
 
       const activeGuests = data.guests.filter((guest) => guest.result === 'ok');
-      if (activeGuests.length > 0) {
-        return bot.reply(message, [
+      if (activeGuests.length === 0) {
+        return bot.reply(message, 'No hay panas activos, invitá uno!');
+      }
+
+      return bot.reply(message, [
           'Tus panas:',
           '\n',
           `${activeGuests.map((guest) => guest.guest).join('\n')}`,
         ].join(' '));
-      }
     })
     .catch(err => {
       debug('catch');

--- a/lib/invitados.js
+++ b/lib/invitados.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const Promise = require('bluebird');
+const request = require('superagent-bluebird-promise');
+const debug = require('debug')('bot:invitados');
+const logError = require('debug')('bot:error');
+const config = require('./config');
+
+function invitados(bot, message) {
+  debug('begin');
+  let user = message.user;
+  let getData = Promise.promisify(bot.botkit.storage.users.get);
+
+  return getData(user)
+    .then((data) => {
+      debug('pana', data);
+      debug('panas', data.guests);
+
+      if(data.guests.length === 0) {
+        return bot.reply(message, 'Oiga, invitá un pana primero!');
+      }
+
+      const activeGuests = data.guests.filter((guest) => guest.result === 'ok');
+      debug({ activeGuests });
+      if(activeGuests.length > 0) {
+        return bot.reply(message, [
+          'Tus panas:',
+          '\n',
+          `${activeGuests.map((guest) => guest.guest).join('\n')}`
+        ].join(' '));
+      }
+    })
+    .catch(err => {
+      debug('catch');
+      let serverError = (err.res && err.res.statusCode !== 200);
+
+      if (serverError) {
+        err.reply = `El servidor respondió de mala gana con estatus ${err.res.statusCode}`;
+      }
+
+      if (err.reply) {
+        logError('caught', err.reply);
+        return bot.reply(message, err.reply);
+      }
+
+      logError('caught', err);
+      return bot.reply(message, 'Error - servidor falló');
+    })
+}
+
+module.exports = invitados;

--- a/lib/invitados.js
+++ b/lib/invitados.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const Promise = require('bluebird');
-const request = require('superagent-bluebird-promise');
 const debug = require('debug')('bot:invitados');
 const logError = require('debug')('bot:error');
-const config = require('./config');
 
 function invitados(bot, message) {
   debug('begin');

--- a/test/guests.js
+++ b/test/guests.js
@@ -16,7 +16,7 @@ test.beforeEach(t => {
   let bot = new BotHelper({ storage });
   let message = new MessageHelper({
     user: 'userID',
-    match: ['invitados', 'mis parceros'],
+    match: ['parceros', 'llaverias', 'neas', 'ñeros', 'invitados'],
   });
 
   // setup user stubbed data
@@ -42,7 +42,7 @@ test('it replies when user has not guests', t => {
 
   let { bot, message } = t.context;
   let { storage } = bot.botkit;
-  let reply = 'Oiga, invitá un parcero primero!';
+  let reply = 'Oe, invitá un parcero primero!';
 
   let hostData = {
     guests: [],
@@ -96,5 +96,21 @@ test('it replies when user has active guests', t => {
 
   return guests(bot, message).then(() => {
     t.is(bot.reply.args[0][1], reply, 'bot replied');
+  });
+});
+
+test('it replies with error message if something along flow errors', t => {
+  t.plan(1);
+
+  let { bot, message } = t.context;
+  let { storage } = bot.botkit;
+  let reply = 'Error - servidor falló';
+
+  // force database failure
+  storage.users.get.callsArgWith(1, new Error('fake db failure'), {});
+
+  // make invitation request
+  return guests(bot, message).then(() => {
+    t.is(bot.reply.args[0][1], reply, 'called with text');
   });
 });

--- a/test/guests.js
+++ b/test/guests.js
@@ -71,9 +71,9 @@ test('it replies when user has active guests', t => {
     { guest: 'foo@gmail.com', result: 'already_in_team' },
   ];
   let reply = [
-    'Tus parceros:',
+     'Tus parceros:',
     '\n',
-    `${activeGuests.map((guest) => `${guest.guest}: ${guestsInviteResults[guest.result]}`).join('\n')}`,
+    `${activeGuests.map((guest) => `${guest.guest}: ${guestsInviteResults[guest.result] || guest.result}`).join('\n')}`,
   ].join(' ');
 
   let hostData = {

--- a/test/guests.js
+++ b/test/guests.js
@@ -55,37 +55,25 @@ test('it replies when user has not guests', t => {
   });
 });
 
-test('it replies when user has not active guests', t => {
-  t.plan(1);
-
-  let { bot, message } = t.context;
-  let { storage } = bot.botkit;
-  let reply = 'No hay parceros activos, invitá uno ome!';
-
-  let hostData = {
-    guests: [{ guest: 'previous@gmail.com', result: 'already_invited' }],
-  };
-
-  storage.users.get.callsArgWith(1, null, hostData);
-
-  return guests(bot, message).then(() => {
-    t.is(bot.reply.args[0][1], reply, 'bot replied');
-  });
-});
-
 test('it replies when user has active guests', t => {
   t.plan(1);
+
+  let guestsInviteResults = {
+    ok: 'Invitado',
+    already_invited: 'Ya se invitó',
+    already_in_team: 'Ya está registrado',
+  };
 
   let { bot, message } = t.context;
   let { storage } = bot.botkit;
   let activeGuests = [
     { guest: 'previous@gmail.com', result: 'ok' },
-    { guest: 'foo@gmail.com', result: 'ok' },
+    { guest: 'foo@gmail.com', result: 'already_in_team' },
   ];
   let reply = [
     'Tus parceros:',
     '\n',
-    `${activeGuests.map((guest) => guest.guest).join('\n')}`,
+    `${activeGuests.map((guest) => `${guest.guest}: ${guestsInviteResults[guest.result]}`).join('\n')}`,
   ].join(' ');
 
   let hostData = {

--- a/test/guests.js
+++ b/test/guests.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// = require modules
+const test = require('ava');
+const moment = require('moment');
+const guests = require('../lib/guests');
+
+// = require test helpers
+const BotHelper = require('./helpers/bot');
+const StorageHelper = require('./helpers/storage');
+const MessageHelper = require('./helpers/message');
+
+test.beforeEach(t => {
+  // initialize helpers
+  let storage = new StorageHelper();
+  let bot = new BotHelper({ storage });
+  let message = new MessageHelper({
+    user: 'userID',
+    match: ['invitados', 'mis parceros'],
+  });
+
+  // setup user stubbed data
+  let createdAt = moment().subtract(100, 'days');
+  let hostData = {
+    id: message.user,
+    createdAt,
+  };
+
+  storage.users.get.callsArgWith(1, null, hostData);
+
+  // export context
+  t.context = {
+    bot,
+    message,
+    hostData,
+  };
+
+});
+
+test('it replies when user has not guests', t => {
+  t.plan(1);
+
+  let { bot, message } = t.context;
+  let { storage } = bot.botkit;
+  let reply = 'Oiga, invitá un parcero primero!';
+
+  let hostData = {
+    guests: [],
+  };
+
+  storage.users.get.callsArgWith(1, null, hostData);
+
+  return guests(bot, message).then(() => {
+    t.is(bot.reply.args[0][1], reply, 'bot replied');
+  });
+});
+
+test('it replies when user has not active guests', t => {
+  t.plan(1);
+
+  let { bot, message } = t.context;
+  let { storage } = bot.botkit;
+  let reply = 'No hay parceros activos, invitá uno ome!';
+
+  let hostData = {
+    guests: [{ guest: 'previous@gmail.com', result: 'already_invited' }],
+  };
+
+  storage.users.get.callsArgWith(1, null, hostData);
+
+  return guests(bot, message).then(() => {
+    t.is(bot.reply.args[0][1], reply, 'bot replied');
+  });
+});
+
+test('it replies when user has active guests', t => {
+  t.plan(1);
+
+  let { bot, message } = t.context;
+  let { storage } = bot.botkit;
+  let activeGuests = [
+    { guest: 'previous@gmail.com', result: 'ok' },
+    { guest: 'foo@gmail.com', result: 'ok' },
+  ];
+  let reply = [
+    'Tus parceros:',
+    '\n',
+    `${activeGuests.map((guest) => guest.guest).join('\n')}`,
+  ].join(' ');
+
+  let hostData = {
+    guests: activeGuests,
+  };
+
+  storage.users.get.callsArgWith(1, null, hostData);
+
+  return guests(bot, message).then(() => {
+    t.is(bot.reply.args[0][1], reply, 'bot replied');
+  });
+});


### PR DESCRIPTION
Implements #10 

This PR adds the command `invitados`, which returns a list of invited and active users with the following format:

**Active guests**:
Tus panas: 
foo@gmail.com
bar@gmail.com

**No active guests**:
No hay panas activos

**No guests**:
Oiga, invitá un pana primero!

Also, you can use `mis panas` command if you are feeling special.
